### PR TITLE
Set the apt frontend to non-interactive.

### DIFF
--- a/16.01/Dockerfile
+++ b/16.01/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:16.04
 MAINTAINER Henning Vogt "henning.vogt@hausgold.de"
 
 # You can change this environment variable on run's with -e
-ENV MDNS_HOSTNAME=ejabberd.local
+ENV \
+  DEBIAN_FRONTEND="noninteractive" \
+  MDNS_HOSTNAME="ejabberd.local"
 
 # Install system packages
 RUN apt-get update -yqqq && \

--- a/17.11/Dockerfile
+++ b/17.11/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:18.04
 MAINTAINER Hermann Mayer "hermann.mayer92@gmail.com"
 
 # You can change this environment variable on run's with -e
-ENV MDNS_HOSTNAME=ejabberd.local
+ENV \
+  DEBIAN_FRONTEND="noninteractive" \
+  MDNS_HOSTNAME="ejabberd.local"
 
 # Install system packages
 RUN apt-get update -yqqq && \


### PR DESCRIPTION
```bash
Setting up libasan4:amd64 (7.2.0-18ubuntu2) ...
Setting up sudo (1.8.21p2-3ubuntu1) ...
Setting up liberror-perl (0.17025-1) ...
Setting up libldap-common (2.4.45+dfsg-1ubuntu1) ...
Setting up libcilkrts5:amd64 (7.2.0-18ubuntu2) ...
Setting up tzdata (2018c-1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------
Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.
  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```